### PR TITLE
Fix missing close functionality on auth forms

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,15 +1,35 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { XIcon } from 'lucide-react'
 import { AuthSlider } from '@/features/auth'
+import { Button } from '@/shared/ui/common/button'
 
 export default function AuthLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const router = useRouter()
+
+  const closeForm = () => {
+    router.push('/')
+  }
+
   return (
     <main className='flex h-screen items-center justify-center bg-slate-800'>
       <div className='flex h-full w-full bg-slate-400 xl:h-[752px] xl:w-[1030px] xl:overflow-hidden xl:rounded-2xl'>
         <AuthSlider />
-        <div className='flex-1'>{children}</div>
+        <div className='relative flex-1'>
+          <Button
+            variant='ghost'
+            onClick={closeForm}
+            className='absolute right-2 top-5 z-10 p-2 text-foreground hover:bg-black/10'
+          >
+            <XIcon className='h-4 w-4' />
+          </Button>
+          {children}
+        </div>
       </div>
     </main>
   )


### PR DESCRIPTION
Added a close (X) button to the registration and login forms to allow users to dismiss the form. Previously, there was no way to close the form via UI, and clicking outside did not close it either.
![image](https://github.com/user-attachments/assets/def3f197-1100-462a-8145-657db539294c)
