### PR TITLE
Implement Google Auth Flow

### DIFF
--- a/src/app/google-auth/additional-info/page.tsx
+++ b/src/app/google-auth/additional-info/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { GoogleRegisterFormSchema, GoogleRegisterFormValues } from '@/features/auth/lib'
+import { StepProfile } from '@/features/auth/ui/step-profile'
+import { authApi } from '@/entities/auth'
+import { Button } from '@/shared/ui/common/button'
+import { Form } from '@/shared/ui/common/form'
+import { toast } from 'react-toastify'
+
+const AdditionalInfoPage = () => {
+  const { t } = useTranslation()
+  const router = useRouter()
+
+  const form = useForm<GoogleRegisterFormValues>({
+    resolver: zodResolver(GoogleRegisterFormSchema(t)),
+    defaultValues: {
+      nativeLanguage: undefined,
+      englishLevel: undefined,
+      goals: '',
+    },
+  })
+
+
+  const onSubmit = async (data: GoogleRegisterFormValues) => {
+    try {
+      await authApi.saveGoogleInfo({
+        nativeLanguage: data.nativeLanguage,
+        englishLevel: data.englishLevel,
+        goals: data.goals,
+      })
+
+      toast.success(t('auth.success'))
+      router.push('/chats')
+    } catch (error) {
+      console.error('Failed to save additional info:', error)
+    }
+  }
+
+  return (
+    <div className='px-8 py-8 w-full max-w-[500px] bg-white rounded-2xl overflow-hidden shadow-xl'>
+      <h1 className='mb-3 text-center text-3xl font-semibold text-foreground'>Almost there!</h1>
+      <h2 className='mb-8 text-center text-lg text-foreground'>
+        Please fill in the additional information to complete your registration.
+      </h2>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <StepProfile form={form} />
+
+          <Button type='submit' className='mt-8 w-full' disabled={form.formState.isSubmitting}>
+            
+            Complete registration
+          </Button>
+        </form>
+      </Form>
+    </div>
+  )
+}
+
+export default AdditionalInfoPage

--- a/src/app/google-auth/additional-info/page.tsx
+++ b/src/app/google-auth/additional-info/page.tsx
@@ -4,12 +4,11 @@ import { useRouter } from 'next/navigation'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { GoogleRegisterFormSchema, GoogleRegisterFormValues } from '@/features/auth/lib'
-import { StepProfile } from '@/features/auth/ui/step-profile'
 import { authApi } from '@/entities/auth'
 import { Button } from '@/shared/ui/common/button'
 import { Form } from '@/shared/ui/common/form'
 import { toast } from 'react-toastify'
+import { GoogleRegisterFormSchema, GoogleRegisterFormValues, StepProfile } from '@/features/auth'
 
 const AdditionalInfoPage = () => {
   const { t } = useTranslation()
@@ -48,7 +47,7 @@ const AdditionalInfoPage = () => {
       </h2>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
-          <StepProfile form={form} />
+        <StepProfile<GoogleRegisterFormValues> form={form} />
 
           <Button type='submit' className='mt-8 w-full' disabled={form.formState.isSubmitting}>
             

--- a/src/app/google-auth/callback/page.tsx
+++ b/src/app/google-auth/callback/page.tsx
@@ -1,37 +1,39 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import { authApi } from '@/entities/auth'
 import { saveTokenStorage } from '@/shared/utils'
 
 export default function GoogleCallbackPage() {
   const router = useRouter()
-  const searchParams = useSearchParams()
 
   useEffect(() => {
-    const accessToken = searchParams.get('access_token')
+    if (typeof window !== 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search)
+      const accessToken = urlParams.get('access_token')
 
-    if (accessToken) {
-      saveTokenStorage(accessToken)
-      authApi
-        .isFirstLogin()
-        .then(isFirstLogin => {
-          if (isFirstLogin) {
-            router.push('/google-auth/additional-info')
-          } else {
-            router.push('/chats')
-          }
-        })
-        .catch(error => {
-          console.error('Error checking first login:', error)
-          router.push('/login')
-        })
-    } else {
-      router.push('/login')
+      if (accessToken) {
+        saveTokenStorage(accessToken)
+        authApi
+          .isFirstLogin()
+          .then(isFirstLogin => {
+            if (isFirstLogin) {
+              router.push('/google-auth/additional-info')
+            } else {
+              router.push('/chats')
+            }
+          })
+          .catch(error => {
+            console.error('Error checking first login:', error)
+            router.push('/login')
+          })
+      } else {
+        router.push('/login')
+      }
     }
-  }, [router, searchParams])
+  }, [router])
 
   return (
     <div className='flex h-screen items-center justify-center'>

--- a/src/app/google-auth/callback/page.tsx
+++ b/src/app/google-auth/callback/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
+import { authApi } from '@/entities/auth'
+import { saveTokenStorage } from '@/shared/utils'
+
+export default function GoogleCallbackPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const accessToken = searchParams.get('access_token')
+
+    if (accessToken) {
+      saveTokenStorage(accessToken)
+      authApi
+        .isFirstLogin()
+        .then(isFirstLogin => {
+          if (isFirstLogin) {
+            router.push('/google-auth/additional-info')
+          } else {
+            router.push('/chats')
+          }
+        })
+        .catch(error => {
+          console.error('Error checking first login:', error)
+          router.push('/login')
+        })
+    } else {
+      router.push('/login')
+    }
+  }, [router, searchParams])
+
+  return (
+    <div className='flex h-screen items-center justify-center'>
+      <Loader2 className='h-10 w-10 animate-spin text-primary' />
+    </div>
+  )
+}

--- a/src/app/google-auth/layout.tsx
+++ b/src/app/google-auth/layout.tsx
@@ -1,0 +1,11 @@
+export default function GoogleAuthLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <main className='flex min-h-screen items-center justify-center bg-slate-800'>
+      {children}
+    </main>
+  )
+}

--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -6,8 +6,8 @@ import type {
   AvailableResponse,
   LoginRequestDto,
   RegisterRequestDto,
+  GoogleRegisterRequest
 } from './types'
-import { getAccessToken } from '@/shared/utils'
 
 const endpoints = {
   register: '/sign-up',
@@ -81,12 +81,13 @@ export const authApi = {
     // TODO: Implement logout logic
   },
 
-  saveGoogleInfo: async (data: Record<string, any>): Promise<any> => {
-    const response = await axiosWithAuth.post(endpoints.saveGoogleInfo, data)
-    return response.data
+  saveGoogleInfo: async (
+    data: GoogleRegisterRequest
+  ): Promise<void> => {
+    await axiosWithAuth.post(endpoints.saveGoogleInfo, data)
   },
 
-  isFirstLogin: async (): Promise<boolean> => {
+  isFirstLogin: async (): Promise<AvailableResponse> => {
     const response = await axiosWithAuth.get(endpoints.firstLogin)
     return response.data 
   },

--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -1,4 +1,4 @@
-import { axiosBase } from '@/shared/api'
+import { axiosBase, axiosWithAuth } from '@/shared/api'
 import { TokenTypeEnum } from '@/shared/constants'
 import type { SignalOptions } from '@/shared/types'
 import type {
@@ -7,12 +7,15 @@ import type {
   LoginRequestDto,
   RegisterRequestDto,
 } from './types'
+import { getAccessToken } from '@/shared/utils'
 
 const endpoints = {
   register: '/sign-up',
   login: '/sign-in',
   checkUsername: '/valid/check-username?username=',
   refreshToken: '/refresh-token',
+  saveGoogleInfo: '/api/addition_info/for-google',
+  firstLogin: '/valid/first-login',
 } as const
 
 export const authApi = {
@@ -76,5 +79,15 @@ export const authApi = {
 
   logout: async (): Promise<void> => {
     // TODO: Implement logout logic
+  },
+
+  saveGoogleInfo: async (data: Record<string, any>): Promise<any> => {
+    const response = await axiosWithAuth.post(endpoints.saveGoogleInfo, data)
+    return response.data
+  },
+
+  isFirstLogin: async (): Promise<boolean> => {
+    const response = await axiosWithAuth.get(endpoints.firstLogin)
+    return response.data 
   },
 } as const

--- a/src/entities/auth/types.ts
+++ b/src/entities/auth/types.ts
@@ -26,3 +26,9 @@ export interface AuthResponse {
 export interface AvailableResponse {
   available: boolean
 }
+
+export interface GoogleRegisterRequest {
+  nativeLanguage: string;
+  englishLevel: string;
+  goals: string;
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,2 +1,4 @@
 export * from './model';
 export * from './ui';
+export * from './lib'
+export * from './ui/step-profile'

--- a/src/features/auth/lib/schema.ts
+++ b/src/features/auth/lib/schema.ts
@@ -95,3 +95,28 @@ export const LoginFormSchema = (t: (key: string) => string) =>
   })
 
 export type LoginFormValues = z.infer<ReturnType<typeof LoginFormSchema>>
+
+export const GoogleRegisterFormSchema = (t: TFunction) =>
+  z.object({
+    nativeLanguage: z.enum(
+      Object.values(NativeLangEnum) as [NativeLangType, ...NativeLangType[]],
+      {
+        required_error: t('auth.validation.required'),
+        invalid_type_error: t('auth.validation.nativeInvalid'),
+      },
+    ),
+    englishLevel: z.enum(
+      Object.values(EngLevelEnum) as [EngLevelType, ...EngLevelType[]],
+      {
+        required_error: t('auth.validation.required'),
+        invalid_type_error: t('auth.validation.englishInvalid'),
+      },
+    ),
+    goals: z.string().min(1, {
+      message: t('auth.validation.required'),
+    }),
+  })
+
+export type GoogleRegisterFormValues = z.infer<
+  ReturnType<typeof GoogleRegisterFormSchema>
+>

--- a/src/features/auth/ui/providers.tsx
+++ b/src/features/auth/ui/providers.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/shared/ui/common/button'
 import { GoogleIcon } from '@/shared/ui/icons'
 import { appRoutes } from '@/shared/config'
+import { AppConfig } from '@/shared/constants'
 
 export const Providers = () => {
   const { t } = useTranslation()
@@ -12,7 +13,14 @@ export const Providers = () => {
   const isLogin = path === appRoutes.login
 
   const googleButton = (
-    <Button variant='secondary' className='w-full'>
+    <Button
+      variant='secondary'
+      className='w-full'
+      onClick={() => {
+        window.location.href =
+        AppConfig.apiUrl + '/oauth2/login/google'
+      }}
+    >
       <GoogleIcon />
       {isLogin ? t('auth.loginWithGoogle') : t('auth.signUpWithGoogle')}
     </Button>

--- a/src/features/auth/ui/register-form.tsx
+++ b/src/features/auth/ui/register-form.tsx
@@ -77,7 +77,7 @@ export function RegisterForm() {
         <form onSubmit={form.handleSubmit(onSubmit)}>
           {step === RegisterStepEnum.Credentials && <StepCredentials form={form} />}
 
-          {step === RegisterStepEnum.Profile && <StepProfile form={form} />}
+          {step === RegisterStepEnum.Profile && <StepProfile<RegisterFormValues> form={form} />}
 
           <div className='pt-4'>
             {step === RegisterStepEnum.Credentials && (

--- a/src/features/auth/ui/step-profile.tsx
+++ b/src/features/auth/ui/step-profile.tsx
@@ -1,4 +1,4 @@
-import type { UseFormReturn } from 'react-hook-form'
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form'
 import {
   FormControl,
   FormField,
@@ -16,18 +16,19 @@ import {
 import { cn } from '@/shared/utils'
 import { profileStepData } from '../model'
 
-interface StepProfileProps {
-  form: UseFormReturn<any>
+interface StepProfileProps<T extends FieldValues> {
+  form: UseFormReturn<T>
 }
 
-export const StepProfile = ({ form }: StepProfileProps) => {
+
+export const StepProfile = <T extends FieldValues>({ form }: StepProfileProps<T>) => {
   return (
     <div className='space-y-5 xl:space-y-3'>
       {profileStepData.map(i => (
         <FormField
           key={i.name}
           control={form.control}
-          name={i.name}
+          name={i.name  as Path<T>}
           render={({ field }) => (
             <FormItem className='space-y-1 md:space-y-3'>
               <FormLabel className='form-label required'>{i.label}</FormLabel>

--- a/src/features/auth/ui/step-profile.tsx
+++ b/src/features/auth/ui/step-profile.tsx
@@ -14,11 +14,10 @@ import {
   SelectValue,
 } from '@/shared/ui/common/select'
 import { cn } from '@/shared/utils'
-import type { RegisterFormValues } from '../lib'
 import { profileStepData } from '../model'
 
 interface StepProfileProps {
-  form: UseFormReturn<RegisterFormValues>
+  form: UseFormReturn<any>
 }
 
 export const StepProfile = ({ form }: StepProfileProps) => {


### PR DESCRIPTION
### **✨ What’s done**

 **Created a callback page (/google-auth/callback) that:**

- Receives and saves the access_token from Google.

- Calls the API to check if this is the user's first login.

- Redirects the user either to the chats page or to the additional info form depending on the result.

**Created a page for collecting additional info (/google-auth/additional-info):**

- Reuses the existing StepProfile form component.

- Validates the data with a simplified schema (GoogleRegisterFormSchema).

- Submits the filled form to the server.

**Added two new API methods:**

- saveGoogleInfo() — to save additional user details after Google sign-in.

- isFirstLogin() — to determine whether the current login is the first one.

**🧪 Notes**

- Token is saved locally using saveTokenStorage().

- The additional info page is only shown on the first login after Google authentication.

- Toast notifications are used to show success messages after saving data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Google sign-in button that redirects users to Google OAuth login.
  - Introduced a post-Google authentication flow with callback handling and an additional information form for new users.
  - Implemented a user interface to collect extra registration details (native language, English proficiency, goals) after Google login.
  - Added internationalization support for the new registration flow.

- **Enhancements**
  - Improved layout for Google authentication pages with a centered, styled container.

- **Other**
  - Updated form validation schema and API integration to support new registration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->